### PR TITLE
docs: Add lint checks documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ To use Linta in your project, add the following line to `build.gradle` file.
 lintChecks "com.swvl.lint:linta-android:x.y.z"
 ```
 
+## Documentation
+
+The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
+
+
+| Lint Issue ID           |    Severity   | Description                                                                                               |
+|:-----------------------:|:-------------:| --------------------------------------------------------------------------------------------------------- |
+| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                      |
+| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of                                                   differences in whitespaces, attributes order, or used tools namespace if any                              |
+| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                     |
+| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                              |
+| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                 |
+
+To see how these checks work in action, check our [sample app](https://github.com/swvl/linta/tree/main/sample).
+
 ## License
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ lintChecks "com.swvl.lint:linta-android:x.y.z"
 The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
 
 
-| Lint Issue ID           |    Severity   | Description                                                                                                                                                                          |
-|:-----------------------:|:-------------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                                                                                                 |
+| Lint Issue ID           |    Severity   | Description                                                                                            |
+|:-----------------------:|:-------------:|--------------------------------------------------------------------------------------------------------|
+| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                   |
 | `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, or used tools namespace if any |
-| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                                                                                                |
-| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                                                                                                         |
-| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                                                                                            |
+| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                  |
+| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                           |
+| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                              |
 
 To see how these checks work in action, check our [sample app](https://github.com/swvl/linta/tree/main/sample).
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ lintChecks "com.swvl.lint:linta-android:x.y.z"
 The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
 
 
-| Lint Issue ID           |    Severity   | Description                                                                                               |
-|:-----------------------:|:-------------:| --------------------------------------------------------------------------------------------------------- |
-| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                      |
-| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of                                                   differences in whitespaces, attributes order, or used tools namespace if any                              |
-| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                     |
-| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                              |
-| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                 |
+| Lint Issue ID           |    Severity   | Description                                                                                                                                                                          |
+|:-----------------------:|:-------------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                                                                                                 |
+| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, or used tools namespace if any |
+| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                                                                                                |
+| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                                                                                                         |
+| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                                                                                            |
 
 To see how these checks work in action, check our [sample app](https://github.com/swvl/linta/tree/main/sample).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ lintChecks "com.swvl.lint:linta-android:x.y.z"
 
 The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
 
-
 | Lint Issue ID           |    Severity   | Description                                                                                            |
 |:-----------------------:|:-------------:|--------------------------------------------------------------------------------------------------------|
 | `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                   |


### PR DESCRIPTION
# Description

Adding documentation to our README.md of the currently implemented lint checks; To make it easier for our visitors/contributors to reason about what and when they can use them. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Documentation

## Screenshot

<img width="1043" alt="Screen Shot 2022-10-23 at 3 48 44 PM" src="https://user-images.githubusercontent.com/49809913/197395942-74d0af18-c0ae-4226-a9da-e4429961e272.png">

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
