### PR TITLE
fix: Fix some issues in DuplicateResourceFilesDetector

### DIFF
--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -19,6 +19,7 @@ package com.swvl.lint.checks
 import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.*
 import org.w3c.dom.Document
+import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.io.StringWriter
 import javax.xml.transform.TransformerFactory
@@ -31,8 +32,6 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     data class ResourceDeclaration(val name: String, val locationHandle: Location.Handle)
 
     private val resources = HashMap<String, MutableList<ResourceDeclaration>>()
-
-    private lateinit var currentDocument: String
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean {
         return folderType in setOf(
@@ -49,19 +48,18 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     override fun visitDocument(context: XmlContext, document: Document) {
+        removeToolsNamespaceAttributes(document.firstChild ?: return)
+
         val stringWriter = StringWriter()
 
         // The transformer will auto-order the elements attributes.
         TransformerFactory.newInstance().newTransformer()
             .transform(DOMSource(document), StreamResult(stringWriter))
 
-        currentDocument = stringWriter.toString()
-        stringWriter.flush()
-
-        removeToolsNamespaceAttributes(document.firstChild ?: return)
-
         // Remove whitespaces.
-        currentDocument = currentDocument.replace("\\s+".toRegex(), "")
+        val currentDocument = stringWriter.buffer.replace("\\s+".toRegex(), "")
+
+        stringWriter.flush()
 
         // Cache the document.
         resources[currentDocument] =
@@ -70,28 +68,29 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             }
     }
 
-    private fun removeToolsNamespaceAttributes(node: Node?) {
+    private fun removeToolsNamespaceAttributes(node: Node) {
         // Remove tools namespace and all attributes under it.
-        val attributesCount = node?.attributes?.length ?: 0
-        for (i in 0 until attributesCount) {
-            val attr = node?.attributes?.item(i)
-            if (attr?.namespaceURI == TOOLS_NAMESPACE_URI || attr?.nodeValue == TOOLS_NAMESPACE_URI) {
-                currentDocument = currentDocument.replace(attr.toString(), "")
+        if (node.nodeType == Element.ELEMENT_NODE) {
+            var i = 0
+            while (i < node.attributes.length) {
+                val attr = node.attributes.item(i)
+                if (attr.namespaceURI == TOOLS_NAMESPACE_URI || attr.nodeValue == TOOLS_NAMESPACE_URI) {
+                    node.attributes.removeNamedItem(attr.nodeName)
+                    continue
+                }
+                i++
             }
         }
 
         // Do the same with all children.
-        val childrenCount = node?.childNodes?.length ?: 0
+        val childrenCount = node.childNodes.length
         for (i in 0 until childrenCount) {
-            val child = node?.childNodes?.item(i)
+            val child = node.childNodes.item(i)
             removeToolsNamespaceAttributes(child)
         }
     }
 
     override fun afterCheckRootProject(context: Context) {
-        // Clear the last document.
-        currentDocument = ""
-
         for ((_, resource) in resources) {
             if (resource.size > 1) {
                 val firstLocation = resource[0].locationHandle.resolve()

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -56,6 +56,7 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             .transform(DOMSource(document), StreamResult(stringWriter))
 
         currentDocument = stringWriter.toString()
+        stringWriter.flush()
 
         removeToolsNamespaceAttributes(document.firstChild ?: return)
 

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -59,8 +59,10 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
 
         removeToolsNamespaceAttributes(document.firstChild ?: return)
 
+        // Remove whitespaces.
         currentDocument = currentDocument.replace("\\s+".toRegex(), "")
 
+        // Cache the document.
         resources[currentDocument] =
             resources.getOrDefault(currentDocument, ArrayList()).apply {
                 add(ResourceDeclaration(context.file.name, context.createLocationHandle(document)))
@@ -89,6 +91,9 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     override fun afterCheckRootProject(context: Context) {
+        // Clear the last document.
+        currentDocument = ""
+
         for ((_, resource) in resources) {
             if (resource.size > 1) {
                 val firstLocation = resource[0].locationHandle.resolve()

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -67,24 +67,24 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             }
     }
 
-    private fun removeToolsNamespaceAttributes(child: Node?) {
-        if (child?.childNodes?.length == 0) {
-            return
+    private fun removeToolsNamespaceAttributes(node: Node?) {
+        // Remove all attributes under from the tools namespace.
+        val attributesCount = node?.attributes?.length ?: 0
+        for (i in 0 until attributesCount) {
+            val attr = node?.attributes?.item(i)
+            if (attr?.namespaceURI == TOOLS_NAMESPACE_URI) {
+                currentDocument = currentDocument.replace(
+                    attr.toString(),
+                    ""
+                )
+            }
         }
 
-        val childrenCount = child?.childNodes?.length ?: 0
+        // Do the same with all children.
+        val childrenCount = node?.childNodes?.length ?: 0
         for (i in 0 until childrenCount) {
-            val subChild = child?.childNodes?.item(i)
-            val attributesCount = subChild?.attributes?.length ?: 0
-            for (j in 0 until attributesCount) {
-                val attr = subChild?.attributes?.item(j)
-                if (attr?.namespaceURI == TOOLS_NAMESPACE_URI)
-                    currentDocument = currentDocument.replace(
-                        attr.toString(),
-                        ""
-                    )
-            }
-            removeToolsNamespaceAttributes(subChild)
+            val child = node?.childNodes?.item(i)
+            removeToolsNamespaceAttributes(child)
         }
     }
 

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -71,15 +71,12 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     private fun removeToolsNamespaceAttributes(node: Node?) {
-        // Remove all attributes under from the tools namespace.
+        // Remove tools namespace and all attributes under it.
         val attributesCount = node?.attributes?.length ?: 0
         for (i in 0 until attributesCount) {
             val attr = node?.attributes?.item(i)
-            if (attr?.namespaceURI == TOOLS_NAMESPACE_URI) {
-                currentDocument = currentDocument.replace(
-                    attr.toString(),
-                    ""
-                )
+            if (attr?.namespaceURI == TOOLS_NAMESPACE_URI || attr?.nodeValue == TOOLS_NAMESPACE_URI) {
+                currentDocument = currentDocument.replace(attr.toString(), "")
             }
         }
 

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -28,7 +28,7 @@ import org.junit.runners.JUnit4
 class DuplicateResourceFilesDetectorTest {
 
     @Test
-    fun `Given duplicate shape resources with different white-spacing, an error should be reported`() {
+    fun `Given duplicate shape resources with different white-spacing, a warning should be reported`() {
         TestLintTask.lint()
             .files(
                 xml(
@@ -69,7 +69,7 @@ class DuplicateResourceFilesDetectorTest {
     }
 
     @Test
-    fun `Given different shape resources, no error should be reported`() {
+    fun `Given different shape resources, no warning should be reported`() {
         TestLintTask.lint()
             .files(
                 xml(
@@ -106,7 +106,7 @@ class DuplicateResourceFilesDetectorTest {
     }
 
     @Test
-    fun `Given 2 identical resources with different attributes that are under the tools namespace, an error should be reported`() {
+    fun `Given 2 duplicate resources with different attributes that are under the tools namespace, a warning should be reported`() {
         TestLintTask.lint()
             .files(
                 xml(
@@ -173,7 +173,7 @@ class DuplicateResourceFilesDetectorTest {
     }
 
     @Test
-    fun `Given duplicate resources with different attributes order, an error should be reported`() {
+    fun `Given duplicate resources with different attributes order, a warning should be reported`() {
         TestLintTask.lint()
             .files(
                 xml(
@@ -191,7 +191,6 @@ class DuplicateResourceFilesDetectorTest {
                                 android:color="@color/black_10" />
                         </shape>
                     </inset>
-
                     """
                 ).indented(),
                 xml(
@@ -219,7 +218,7 @@ class DuplicateResourceFilesDetectorTest {
     }
 
     @Test
-    fun `Given duplicate shape resources, where one doesn't have the xml declaration, an error should be reported`() {
+    fun `Given duplicate shape resources, where one doesn't have the xml declaration, a warning should be reported`() {
         TestLintTask.lint()
             .files(
                 xml(

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -106,6 +106,47 @@ class DuplicateResourceFilesDetectorTest {
     }
 
     @Test
+    fun `Given 2 duplicate resources, one with attributes that are under the tools namespace and another without, a warning should be reported`() {
+        TestLintTask.lint()
+            .files(
+                xml(
+                    "res/layout/item_title.xml",
+                    """
+                    <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+                        xmlns:tools="http://schemas.android.com/tools"
+                        android:id="@+id/tv_id"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?selectableItemBackground"
+                        android:paddingHorizontal="32dp"
+                        android:paddingVertical="16dp"
+                        android:textColor="#000000"
+                        android:textSize="20sp"
+                        tools:text="Title" />
+                    """
+                ).indented(),
+                xml(
+                    "res/layout/item_option.xml",
+                    """
+                    <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/tv_id"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?selectableItemBackground"
+                        android:paddingHorizontal="32dp"
+                        android:paddingVertical="16dp"
+                        android:textColor="#000000"
+                        android:textSize="20sp" />
+                    """
+                ).indented()
+            )
+            .issues(DuplicateResourceFilesDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectCount(1, Severity.WARNING)
+    }
+
+    @Test
     fun `Given 2 duplicate resources with different attributes that are under the tools namespace, a warning should be reported`() {
         TestLintTask.lint()
             .files(

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -32,7 +32,7 @@ class DuplicateResourceFilesDetectorTest {
         TestLintTask.lint()
             .files(
                 xml(
-                    "res/drawable/shape.xml",
+                    "res/drawable/shape1.xml",
                     """
                     <shape xmlns:android="http://schemas.android.com/apk/res/android"
                         android:shape="rectangle">
@@ -73,7 +73,7 @@ class DuplicateResourceFilesDetectorTest {
         TestLintTask.lint()
             .files(
                 xml(
-                    "res/drawable/shape.xml",
+                    "res/drawable/shape1.xml",
                     """
                     <shape xmlns:android="http://schemas.android.com/apk/res/android"
                         android:shape="rectangle">
@@ -218,7 +218,7 @@ class DuplicateResourceFilesDetectorTest {
         TestLintTask.lint()
             .files(
                 xml(
-                    "res/drawable/resource.xml",
+                    "res/drawable/resource1.xml",
                     """
                     <inset xmlns:android="http://schemas.android.com/apk/res/android"
                         android:insetTop="-1dp">
@@ -263,7 +263,7 @@ class DuplicateResourceFilesDetectorTest {
         TestLintTask.lint()
             .files(
                 xml(
-                    "res/drawable/shape.xml",
+                    "res/drawable/shape1.xml",
                     """
                     <?xml version="1.0" encoding="utf-8"?>
                     <shape xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
# Description

There were 3 issues in `DuplicateResourceFilesDetector`.

1. It doesn't remove attributes from the tools namespace in the root node.
2. It doesn't remove the tools namespace itself.
3. Remove tools namespace attributes node instead of replacing the string.

The issues are fixed and validated by re-running the existing tests and by adding a new test validating the first two cases.

The lint check also runs faster now because it removes the specific elements only instead of replacing the whole string.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
