### PR TITLE
feat: Add GitHub Action to auto assign PR author

### DIFF
--- a/.github/workflows/assign-pr-author.yml
+++ b/.github/workflows/assign-pr-author.yml
@@ -1,0 +1,12 @@
+# This GitHub action will auto-assign the PR author as an assignee and will not override the assignee if it's already assigned manually.
+
+name: Assign Author
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: technote-space/assign-author@v1.3.1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Description

This GitHub action will auto-assign the PR author as an assignee and will not override the assignee if it's already assigned manually.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
