### PR TITLE
fix: Run PR comment step on Bitrise only if it was a PR build

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,9 +4,9 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: android
 trigger_map:
   - pull_request_target_branch: '*'
-    workflow: pull-request
+    workflow: primary
 workflows:
-  pull-request:
+  primary:
     description: |
       Runs Linta lint checks unit tests.
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,6 +41,7 @@ workflows:
                 {{end}}| [{{$element.File}}]({{$element.URL}}) |{{end}}
       - comment-on-github-pull-request@0:
           title: Comment Bitrise Build Result on the PR
+          run_if: .IsPR
           inputs:
             - body: |-
                 ## Bitrise


### PR DESCRIPTION
# Description

Run PR comment step on Bitrise only if it was a PR build, to not cause the build to fail in case the workflow is manually run without a PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
