### PR TITLE
chore: Exclude LintIssueRegistry from Jacoco test coverage report

### DIFF
--- a/linta-android/build.gradle.kts
+++ b/linta-android/build.gradle.kts
@@ -58,6 +58,7 @@ tasks.jacocoTestReport {
     classDirectories.setFrom(
         files(
             sourceSets.main.get().output.asFileTree.matching {
+                // Exclude the issue registry, since there is nothing to be tested there.
                 exclude("com/swvl/lint/LintIssueRegistry.class")
             }
         )

--- a/linta-android/build.gradle.kts
+++ b/linta-android/build.gradle.kts
@@ -52,7 +52,16 @@ tasks.jacocoTestReport {
         xml.required.set(true)
         html.required.set(false)
     }
+
     dependsOn(tasks.test)
+
+    classDirectories.setFrom(
+        files(
+            sourceSets.main.get().output.asFileTree.matching {
+                exclude("com/swvl/lint/LintIssueRegistry.class")
+            }
+        )
+    )
 }
 
 mavenPublishing {


### PR DESCRIPTION
# Description

Exclude `LintIssueRegistry` from Jacoco test coverage report, since no unit tests should be written for it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
