### PR TITLE
fix: Replace toUpperCase usages with uppercase in ColorUtils.kt

### DIFF
--- a/linta-android/src/main/java/com/swvl/lint/utils/ColorUtils.kt
+++ b/linta-android/src/main/java/com/swvl/lint/utils/ColorUtils.kt
@@ -40,7 +40,7 @@ object ColorUtils {
      * @return the 8-digit hexadecimal format of a color of any length.
      */
     fun get8DigitColorFormat(hexColor: String): String {
-        val newColor = hexColor.toUpperCase(Locale.US)
+        val newColor = hexColor.uppercase(Locale.US)
 
         return when (newColor.length) {
             9 -> {
@@ -83,7 +83,7 @@ object ColorUtils {
      * format if an alpha component exists.
      */
     fun getBestColorFormat(hexColor: String): String {
-        val newColor = hexColor.toUpperCase(Locale.US)
+        val newColor = hexColor.uppercase(Locale.US)
 
         return when (newColor.length) {
             9 -> {


### PR DESCRIPTION
# Description

This PR replaces `toUpperCase` usages with `uppercase` in ColorUtils.kt as the previous one in deprecated

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
