### PR TITLE
feat: Ignore comment nodes in DuplicateResourceFilesDetector.kt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ lintChecks "com.swvl.lint:linta-android:x.y.z"
 
 The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
 
-| Lint Issue ID           |    Severity   | Description                                                                                            |
-|:-----------------------:|:-------------:|--------------------------------------------------------------------------------------------------------|
-| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                   |
-| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, or used tools namespace if any |
-| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                  |
-| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                           |
-| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                              |
+| Lint Issue ID           |    Severity   | Description                                                                                                                                                                                   |
+|:-----------------------:|:-------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                                                                                                          |
+| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, comments or used tools namespace if any |
+| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                                                                                                         |
+| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                                                                                                                  |
+| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                                                                                                     |
 
 To see how these checks work in action, check the [generated lint report](https://github.com/swvl/linta/tree/main/sample/build/reports/lint-results-release.html) in our [sample app](https://github.com/swvl/linta/tree/main/sample).
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ lintChecks "com.swvl.lint:linta-android:x.y.z"
 
 The following are the lint checks currently implemented by Linta [please add the documentation to any recent addition and/or any missing ones]:
 
-| Lint Issue ID           |    Severity   | Description                                                                                                                                                                                   |
-|:-----------------------:|:-------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                                                                                                          |
-| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, comments or used tools namespace if any |
-| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                                                                                                         |
-| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                                                                                                                  |
-| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                                                                                                     |
+| Lint Issue ID           |    Severity   | Description                                                                                                                                                                                    |
+|:-----------------------:|:-------------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DuplicateColors`       |    warning    | When a duplicate color is defined in a resource file                                                                                                                                           |
+| `DuplicateResourceFiles`|    warning    | When there are two or more duplicate resource files containing the same exact attributes, regardless of differences in whitespaces, attributes order, comments, or used tools namespace if any |
+| `HardcodedColorSrcCode` |     error     | When a hardcoded color is used in a source code file (Java or Kotlin)                                                                                                                          |
+| `HardcodedColorXml`     |     error     | When a hardcoded color is used in a resource file (drawables, layouts, etc.)                                                                                                                   |
+| `RedundantStyles`       |    warning    | When a style is created without adding any new attributes                                                                                                                                      |
 
 To see how these checks work in action, check the [generated lint report](https://github.com/swvl/linta/tree/main/sample/build/reports/lint-results-release.html) in our [sample app](https://github.com/swvl/linta/tree/main/sample).
 

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -48,7 +48,7 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     override fun visitDocument(context: XmlContext, document: Document) {
-        removeToolsNamespaceAttributes(document.firstChild ?: return)
+        removeToolsNamespaceAttributesAndComments(document.firstChild ?: return)
 
         val stringWriter = StringWriter()
 
@@ -68,7 +68,7 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             }
     }
 
-    private fun removeToolsNamespaceAttributes(node: Node) {
+    private fun removeToolsNamespaceAttributesAndComments(node: Node) {
         // Remove tools namespace and all attributes under it.
         if (node.nodeType == Element.ELEMENT_NODE) {
             var i = 0
@@ -90,7 +90,7 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
         var i = 0
         while (i < node.childNodes.length) {
             val child = node.childNodes.item(i)
-            removeToolsNamespaceAttributes(child)
+            removeToolsNamespaceAttributesAndComments(child)
 
             // Only increase counter if node isn't a comment
             if (child.nodeType == Element.COMMENT_NODE)

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -81,12 +81,21 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
                 i++
             }
         }
+        // Remove comment nodes.
+        else if (node.nodeType == Element.COMMENT_NODE) {
+            node.parentNode.removeChild(node)
+        }
 
         // Do the same with all children.
-        val childrenCount = node.childNodes.length
-        for (i in 0 until childrenCount) {
+        var i = 0
+        while (i < node.childNodes.length) {
             val child = node.childNodes.item(i)
             removeToolsNamespaceAttributes(child)
+
+            // Only increase counter if node isn't a comment
+            if (child.nodeType == Element.COMMENT_NODE)
+                continue
+            i++
         }
     }
 

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -73,8 +73,8 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     private fun removeToolsNamespaceAttributesAndComments(node: Node) {
-        // Remove tools namespace and all attributes under it.
         if (node.nodeType == Element.ELEMENT_NODE) {
+            // Remove tools namespace and all attributes under it.
             var i = 0
             while (i < node.attributes.length) {
                 val attr = node.attributes.item(i)
@@ -84,9 +84,8 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
                 }
                 i++
             }
-        }
-        // Remove comment nodes.
-        else if (node.nodeType == Element.COMMENT_NODE) {
+        } else if (node.nodeType == Element.COMMENT_NODE) {
+            // Remove comment nodes.
             node.parentNode.removeChild(node)
         }
 

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -95,7 +95,7 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             val child = node.childNodes.item(i)
             removeToolsNamespaceAttributesAndComments(child)
 
-            // Only increase counter if node isn't a comment
+            // Only increase the counter if the node isn't a comment.
             if (child.nodeType == Element.COMMENT_NODE) {
                 continue
             }

--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -96,8 +96,9 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
             removeToolsNamespaceAttributesAndComments(child)
 
             // Only increase counter if node isn't a comment
-            if (child.nodeType == Element.COMMENT_NODE)
+            if (child.nodeType == Element.COMMENT_NODE) {
                 continue
+            }
             i++
         }
     }

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -295,4 +295,78 @@ class DuplicateResourceFilesDetectorTest {
             .run()
             .expectCount(1, Severity.WARNING)
     }
+
+    @Test
+    fun `Given 2 duplicate layouts where one has comments and the other doesn't, a warning should be reported`() {
+        TestLintTask.lint()
+            .files(
+                xml(
+                    "res/layout/layout1.xml",
+                    """
+                    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center|start"
+                        android:orientation="horizontal"
+                        android:paddingBottom="16dp">
+                        <!-- This is a button -->
+                        <Button
+                            android:id="@+id/addPassenger_button"
+                            style="@style/Widget.App.Button.Outlined.Primary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="20dp"
+                            android:paddingEnd="20dp"
+                            android:text="@string/travel_bookingConfirmation_addPassenger_button_title" />
+                            
+                        <!-- End of layout -->
+                        
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center|start"
+                            android:orientation="horizontal">
+                            
+                            <!-- empty layout -->
+                            
+                        </LinearLayout>
+
+                    </LinearLayout>
+                    """
+                ).indented(),
+                xml(
+                    "res/layout/layout2.xml",
+                    """
+                    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center|start"
+                        android:orientation="horizontal"
+                        android:paddingBottom="16dp">
+
+                        <Button
+                            android:id="@+id/addPassenger_button"
+                            style="@style/Widget.App.Button.Outlined.Primary"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="20dp"
+                            android:paddingEnd="20dp"
+                            android:text="@string/travel_bookingConfirmation_addPassenger_button_title" />
+                            
+                            <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="center|start"
+                            android:orientation="horizontal">
+                            </LinearLayout>
+
+                    </LinearLayout>
+                    """
+                ).indented()
+            )
+            .issues(DuplicateResourceFilesDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectCount(1, Severity.WARNING)
+    }
 }

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -368,7 +368,9 @@ class DuplicateResourceFilesDetectorTest {
             .allowMissingSdk()
             .run()
             .expectCount(1, Severity.WARNING)
+    }
 
+    @Test
     fun `Given a resource with hardcoded colors but with the lint issue suppressed, when the duplicate resource files detector is run before the hardcoded color detector, no issue should be reported`() {
         TestLintTask.lint()
             .files(

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -327,7 +327,7 @@ class DuplicateResourceFilesDetectorTest {
                             android:gravity="center|start"
                             android:orientation="horizontal">
                             
-                            <!-- empty layout -->
+                            <!-- Empty layout -->
                             
                         </LinearLayout>
 

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -353,12 +353,12 @@ class DuplicateResourceFilesDetectorTest {
                             android:paddingEnd="20dp"
                             android:text="@string/travel_bookingConfirmation_addPassenger_button_title" />
                             
-                            <LinearLayout
+                        <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:gravity="center|start"
                             android:orientation="horizontal">
-                            </LinearLayout>
+                        </LinearLayout>
 
                     </LinearLayout>
                     """


### PR DESCRIPTION
# Description

This PR adds the functionality of ignoring comment nodes when checking xml files in DuplicateResourceFilesDetector as comment nodes are of no value to the actual resource

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshot(s)

<img width="1095" alt="Screen Shot 2022-11-03 at 11 06 51 AM" src="https://user-images.githubusercontent.com/49809913/199682685-e50982b9-02bc-4135-b0d7-5eb40e3106cd.png">

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
