### PR TITLE
fix: Clone the document before removing nodes in DuplicateResourceFilesDetector

### DIFF
--- a/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
+++ b/linta-android/src/main/java/com/swvl/lint/checks/DuplicateResourceFilesDetector.kt
@@ -48,13 +48,17 @@ class DuplicateResourceFilesDetector : ResourceXmlDetector() {
     }
 
     override fun visitDocument(context: XmlContext, document: Document) {
-        removeToolsNamespaceAttributes(document.firstChild ?: return)
+        // Deep clone the document to not affect the original document, as the same document
+        // instance is used in all other lint detectors.
+        val documentClone = document.cloneNode(true)
+
+        removeToolsNamespaceAttributes(documentClone.firstChild ?: return)
 
         val stringWriter = StringWriter()
 
         // The transformer will auto-order the elements attributes.
         TransformerFactory.newInstance().newTransformer()
-            .transform(DOMSource(document), StreamResult(stringWriter))
+            .transform(DOMSource(documentClone), StreamResult(stringWriter))
 
         // Remove whitespaces.
         val currentDocument = stringWriter.buffer.replace("\\s+".toRegex(), "")

--- a/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
+++ b/linta-android/src/test/java/com/swvl/lint/checks/DuplicateResourceFilesDetectorTest.kt
@@ -295,4 +295,30 @@ class DuplicateResourceFilesDetectorTest {
             .run()
             .expectCount(1, Severity.WARNING)
     }
+
+    @Test
+    fun `Given a resource with hardcoded colors but with the lint issue suppressed, when the duplicate resource files detector is run before the hardcoded color detector, no issue should be reported`() {
+        TestLintTask.lint()
+            .files(
+                xml(
+                    "res/drawable/shape.xml",
+                    """
+                    <shape xmlns:android="http://schemas.android.com/apk/res/android"
+                        xmlns:tools="http://schemas.android.com/tools"
+                        android:shape="rectangle"
+                        tools:ignore="HardcodedColorXml">
+                        <solid android:color="#FFFFFF" />
+                        <stroke
+                            android:width="1dp"
+                            android:color="#000000" />
+                        <corners android:radius="24dp" />
+                    </shape>
+                    """
+                ).indented()
+            )
+            .issues(DuplicateResourceFilesDetector.ISSUE, HardcodedColorXmlDetector.ISSUE)
+            .allowMissingSdk()
+            .run()
+            .expectClean()
+    }
 }


### PR DESCRIPTION
# Description

Deep clone the document in `DuplicateResourceFilesDetector` to not affect the original document, as the same document instance is used in all other lint detectors, affecting the other lint detectors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
